### PR TITLE
fix: do not update coverage in loop for faster render

### DIFF
--- a/src/routes/(public)/css-coverage/+page.svelte
+++ b/src/routes/(public)/css-coverage/+page.svelte
@@ -48,7 +48,7 @@
 			}
 			let text = await file.text()
 			let parsed = parse_json(text)
-			new_data = new_data.concat(parsed)
+			new_data.push(...parsed)
 		}
 
 		// only update state once to prevent hundreds of re-renders


### PR DESCRIPTION
closes #9 

because we render only once instead of potentially 211 times (in my test case). Still a long blocking task but doesn't warrant the complexity of a worker for now.