### PR TITLE
fix: ignore non-css responses in css scraper

### DIFF
--- a/src/routes/api/get-css/get-css.ts
+++ b/src/routes/api/get-css/get-css.ts
@@ -330,5 +330,5 @@ export async function get_css(url: string, { timeout = 10000 } = {}) {
 
 	clearTimeout(timeout_id)
 
-	return result.filter(({ css }) => css.length !== 0)
+	return result.filter(({ css }) => css.length > 0)
 }


### PR DESCRIPTION
Based on The CSS Selection's metric I dove into the top 20 largest sites and it turns out that pretty much all of them returned non-CSS responses for some resources. This PR checks if the CSS response has the correct type or isn't HTML or JS.