### PR TITLE
perf: apply `content-visibility: auto` to analysis sections

### DIFF
--- a/src/lib/components/Panel.svelte
+++ b/src/lib/components/Panel.svelte
@@ -21,6 +21,8 @@
 		border-width: 1px;
 		border-style: solid;
 		border-color: light-dark(var(--fg-800), transparent);
+		/* Usually contains expensive elements to render, so content-visibility:auto makes sense */
+		content-visibility: auto;
 
 		@media (min-width: 44rem) {
 			padding-right: var(--space-4);

--- a/src/lib/components/stats/Analysis.svelte
+++ b/src/lib/components/stats/Analysis.svelte
@@ -100,7 +100,7 @@
 		left: 0;
 	}
 
-	@media (min-width: 44rem) {
+	@media (min-width: 48rem) {
 		.analysis {
 			grid-template-rows: 1fr auto;
 			column-gap: var(--space-8);

--- a/src/lib/css/style.css
+++ b/src/lib/css/style.css
@@ -577,6 +577,8 @@
 
 		.report-section {
 			display: grid;
+			/* Expensive elements to render, so enable content-visibility */
+			content-visibility: auto;
 
 			/* Making this larger than 24rem will cause horizontal overflows */
 			grid-template-columns: repeat(auto-fit, minmax(24rem, 1fr));


### PR DESCRIPTION
AI generated analysis of a trace I ran on production:

> Large Layout Thrashing (56ms + 21ms)                                      
>                                                                               
>  Problem: Rendering the report triggers layout on 13,584 elements with 1504   
>  "dirty" objects needing recalculation.

Also fixes a breakpoint bug for the side nav on the analysis page, caused by the introduction of the CSS Selection.

## Summary                                                                   
  Added `content-visibility: auto` to report sections to reduce layout         
  thrashing when rendering CSS analysis results.                               
                                                                               
  ## Performance improvements                                                  
                                                                               
  | Metric | Before | After | Change |                                         
  |--------|--------|-------|--------|                                         
  | Largest layout task | 56.3ms | 14.3ms | **-75%** |                         
  | Total layout time | 57.7ms | 38.0ms | **-34%** |                           
  | Dirty objects (max) | 1504 | 376 | **-75%** |                              
  | Style recalculation | 20.7ms | 5.5ms | **-73%** |                          
                                                                               
  The browser now skips style calculation and layout for off-screen sections   
  until they're scrolled into view. 