### PR TITLE
Add URL hash state persistence for raw CSS input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5167,6 +5167,21 @@
 				}
 			}
 		},
+		"node_modules/svelte-check/node_modules/picomatch": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
 		"node_modules/svelte-check/node_modules/readdirp": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",

--- a/src/lib/components/css-form/Form.svelte
+++ b/src/lib/components/css-form/Form.svelte
@@ -13,6 +13,7 @@
 	import { get_css, type CssFetchNetworkError, type CssFetchApiError, type CssFetchRemoteError } from '$lib/get-css'
 	import { get_css_state } from '$lib/css-state.svelte'
 	import { IsOnline } from '$lib/is-online.svelte'
+	import { HashState } from '$lib/url-hash-state.svelte'
 	import type { Snippet } from 'svelte'
 
 	interface Props {
@@ -29,6 +30,8 @@
 	let error: Error | undefined = $state()
 	let url = $state('')
 	let css_state = get_css_state()
+	let raw_hash_state = new HashState<{ css: string }>({ css: '' })
+	let initial_tab: 'url' | 'file' | 'raw' = raw_hash_state.current.css ? 'raw' : 'url'
 	let prettify = $state(page.url.searchParams.has('prettify') ? page.url.searchParams.get('prettify') === '1' : true)
 	let is_online = new IsOnline()
 
@@ -42,11 +45,11 @@
 		let input_val = form_data.get('raw-css')
 		let val = String(input_val)
 
-		// Remove ?url= and prettify= query parameters from the URL
+		// Remove ?url= and prettify= query parameters from the URL, but keep
+		// the hash so the raw CSS state is preserved for sharing
 		let cleaned_url = page.url
 		cleaned_url.searchParams.delete('url')
 		cleaned_url.searchParams.delete('prettify')
-		cleaned_url.hash = ''
 		await goto(cleaned_url, { replaceState: true })
 
 		status = 'idle'
@@ -167,7 +170,7 @@
 	</div>
 {/snippet}
 
-<InputModeSwitcher>
+<InputModeSwitcher default_tab={initial_tab}>
 	{#snippet title()}
 		{@render title_snippet?.()}
 	{/snippet}
@@ -227,7 +230,7 @@
 		<form method="POST" onsubmit={on_submit_raw}>
 			<FormGroup>
 				<Label for="raw-css">CSS to analyze</Label>
-				<Textarea name="raw-css" id="raw-css" wrap_lines required />
+				<Textarea name="raw-css" id="raw-css" wrap_lines required bind:value={raw_hash_state.current.css} />
 			</FormGroup>
 			{@render prettify_option()}
 			<div class="submit">

--- a/src/lib/components/css-form/InputModeSwitcher.svelte
+++ b/src/lib/components/css-form/InputModeSwitcher.svelte
@@ -1,21 +1,24 @@
 <script lang="ts">
 	import { createTabs, melt } from '@melt-ui/svelte'
+	import { untrack } from 'svelte'
 	import type { Snippet } from 'svelte'
-	const {
-		states: { value },
-		elements: { root, list, content: tab_content, trigger }
-	} = createTabs({
-		loop: false,
-		defaultValue: 'url'
-	})
 
 	type Props = {
 		url_tab: Snippet
 		file_tab: Snippet
 		raw_tab: Snippet
 		title: Snippet
+		default_tab?: 'url' | 'file' | 'raw'
 	}
-	let { url_tab, file_tab, raw_tab, title }: Props = $props()
+	let { url_tab, file_tab, raw_tab, title, default_tab = 'url' }: Props = $props()
+
+	const {
+		states: { value },
+		elements: { root, list, content: tab_content, trigger }
+	} = createTabs({
+		loop: false,
+		defaultValue: untrack(() => default_tab)
+	})
 </script>
 
 <div class="input-mode-switcher">


### PR DESCRIPTION
## Summary
This PR adds the ability to persist and share raw CSS input through URL hash state, allowing users to share their CSS analysis via URL without exposing sensitive query parameters.

## Key Changes
- **InputModeSwitcher**: Added `default_tab` prop to allow dynamic tab selection based on URL state, using `untrack()` to prevent reactivity issues during initialization
- **Form component**: 
  - Integrated `HashState` to manage raw CSS persistence in the URL hash
  - Added logic to detect and restore the raw CSS tab when hash state contains CSS data
  - Modified form submission to preserve the hash (containing raw CSS state) while removing query parameters (`url` and `prettify`)
  - Bound the raw CSS textarea to the hash state for automatic synchronization
- **Dependencies**: Added `untrack` import from Svelte for proper reactive state handling

## Implementation Details
- The `raw_hash_state` is initialized with an empty CSS string and automatically syncs with the textarea input
- The `initial_tab` is determined by checking if the hash state contains CSS data, defaulting to 'url' tab otherwise
- Query parameters are cleaned up on form submission while preserving the hash for sharing purposes
- This enables users to share raw CSS analysis links without exposing URL/prettify parameters in the shareable URL

https://claude.ai/code/session_016foMJWiaAwuMiU4VcrL5AV