### PR TITLE
perf: avoid webfont for big H1 on homepage to improve LCP

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -25,7 +25,7 @@
 />
 
 <header>
-	<h1 class="font-heading">
+	<h1 class="title">
 		Your CSS has dirty secrets <br />and <em>Wallace knows them</em>.
 	</h1>
 	<p class="lead">


### PR DESCRIPTION
before:
<img width="1430" height="777" alt="Screenshot 2026-05-27 at 17 58 48" src="https://github.com/user-attachments/assets/3b93ac3a-7c2b-48ca-8742-d6465b379c51" />


after:
<img width="1431" height="774" alt="Screenshot 2026-05-27 at 17 58 38" src="https://github.com/user-attachments/assets/ca2221df-bbec-467b-a843-11f6f78fa2e6" />
