### PR TITLE
Enable static prerendering and improve theme handling

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -4,12 +4,7 @@
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width,initial-scale=1.0" />
 		<meta name="text-scale" content="scale" />
-		<script>
-			(function () {
-				var m = document.cookie.match(/(?:^|;\s*)theme=([^;]+)/);
-				if (m) document.documentElement.setAttribute('data-theme', m[1]);
-			})();
-		</script>
+		<script src="/theme.js"></script>
 		<link rel="icon" type="image/png" href="/favicon.png" />
 		%sveltekit.head%
 		<link

--- a/src/app.html
+++ b/src/app.html
@@ -4,7 +4,7 @@
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width,initial-scale=1.0" />
 		<meta name="text-scale" content="scale" />
-		<script src="/theme.js" nonce="%sveltekit.nonce%"></script>
+		<script src="/theme.js"></script>
 		<link rel="icon" type="image/png" href="/favicon.png" />
 		%sveltekit.head%
 		<link

--- a/src/app.html
+++ b/src/app.html
@@ -1,9 +1,15 @@
 <!doctype html>
-<html lang="en" data-theme="%sveltekit.theme%">
+<html lang="en" data-theme="system">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width,initial-scale=1.0" />
 		<meta name="text-scale" content="scale" />
+		<script>
+			(function () {
+				var m = document.cookie.match(/(?:^|;\s*)theme=([^;]+)/);
+				if (m) document.documentElement.setAttribute('data-theme', m[1]);
+			})();
+		</script>
 		<link rel="icon" type="image/png" href="/favicon.png" />
 		%sveltekit.head%
 		<link

--- a/src/app.html
+++ b/src/app.html
@@ -4,7 +4,7 @@
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width,initial-scale=1.0" />
 		<meta name="text-scale" content="scale" />
-		<script src="/theme.js"></script>
+		<script src="/theme.js" nonce="%sveltekit.nonce%"></script>
 		<link rel="icon" type="image/png" href="/favicon.png" />
 		%sveltekit.head%
 		<link

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -67,11 +67,7 @@ const set_theme: Handle = async function ({ event, resolve }) {
 
 	event.locals.theme = theme
 
-	let response = await resolve(event, {
-		transformPageChunk: ({ html }) => {
-			return html.replace('%sveltekit.theme%', theme)
-		}
-	})
+	let response = await resolve(event)
 	return response
 }
 

--- a/src/routes/(public)/about/+page.server.ts
+++ b/src/routes/(public)/about/+page.server.ts
@@ -1,5 +1,7 @@
 import { faqs } from '../../../../content/faq'
 
+export const prerender = true
+
 export function load() {
 	return {
 		faqs

--- a/src/routes/(public)/blog/+page.server.ts
+++ b/src/routes/(public)/blog/+page.server.ts
@@ -1,5 +1,7 @@
 import { getPostList } from '$lib/blog'
 
+export const prerender = true
+
 export function load() {
 	return {
 		posts: getPostList()

--- a/src/routes/(public)/blog/[slug]/+page.server.ts
+++ b/src/routes/(public)/blog/[slug]/+page.server.ts
@@ -2,6 +2,12 @@ import { error } from '@sveltejs/kit'
 import { getPost, getPostList } from '$lib/blog'
 import type { PageServerLoad } from './$types'
 
+export const prerender = true
+
+export function entries() {
+	return getPostList().map(({ slug }) => ({ slug }))
+}
+
 export const load: PageServerLoad = ({ params }) => {
 	let post = getPost(params.slug)
 

--- a/src/routes/(public)/css-code-quality/+page.server.ts
+++ b/src/routes/(public)/css-code-quality/+page.server.ts
@@ -1,7 +1,5 @@
 import { getDocs } from '$lib/code-quality'
 
-export const prerender = true
-
 export function load() {
 	return {
 		docs: getDocs()

--- a/src/routes/(public)/css-code-quality/+page.server.ts
+++ b/src/routes/(public)/css-code-quality/+page.server.ts
@@ -1,5 +1,7 @@
 import { getDocs } from '$lib/code-quality'
 
+export const prerender = true
+
 export function load() {
 	return {
 		docs: getDocs()

--- a/src/routes/(public)/docs/+layout.server.ts
+++ b/src/routes/(public)/docs/+layout.server.ts
@@ -1,6 +1,8 @@
 import { getGroups } from '$lib/metric-groups'
 import { getRecipes } from '$lib/recipes'
 
+export const prerender = true
+
 export function load() {
 	return {
 		allGroups: getGroups(),

--- a/src/routes/(public)/docs/metrics/[slug]/+page.server.ts
+++ b/src/routes/(public)/docs/metrics/[slug]/+page.server.ts
@@ -2,6 +2,12 @@ import { error } from '@sveltejs/kit'
 import { getMetrics } from '$lib/metrics'
 import type { PageServerLoad } from './$types'
 
+export const prerender = true
+
+export function entries() {
+	return getMetrics().map(({ slug }) => ({ slug }))
+}
+
 export const load: PageServerLoad = ({ params }) => {
 	const page = getMetrics().find((doc) => params.slug === doc.slug)
 

--- a/src/routes/(public)/docs/recipes/[slug]/+page.server.ts
+++ b/src/routes/(public)/docs/recipes/[slug]/+page.server.ts
@@ -2,6 +2,12 @@ import { error } from '@sveltejs/kit'
 import { getRecipes } from '$lib/recipes'
 import type { PageServerLoad } from './$types'
 
+export const prerender = true
+
+export function entries() {
+	return getRecipes().map(({ slug }) => ({ slug }))
+}
+
 export const load: PageServerLoad = ({ params }) => {
 	const page = getRecipes().find((p) => params.slug === p.slug)
 

--- a/static/theme.js
+++ b/static/theme.js
@@ -1,0 +1,4 @@
+(function () {
+	var m = document.cookie.match(/(?:^|;\s*)theme=([^;]+)/);
+	if (m) document.documentElement.setAttribute('data-theme', m[1]);
+})();

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -13,9 +13,7 @@ const config = {
 	preprocess: [vitePreprocess(), mdsvex(mdsvexConfig), preprocessMeltUI()],
 
 	kit: {
-		adapter: adapter({
-			edge: true
-		}),
+		adapter: adapter(),
 		serviceWorker: {
 			register: false
 		},

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -22,7 +22,7 @@ const config = {
 		},
 		csp: {
 			directives: {
-				'script-src': ['counterscale.bartveneman.workers.dev', 'self'],
+				'script-src': ['counterscale.bartveneman.workers.dev', 'self', 'sha256-i711g134ddjh7/AVqzinfA+vmpz5El3oRK6Z+QRNcq4='],
 				'connect-src': ['self', 'counterscale.bartveneman.workers.dev'],
 				'style-src': ['self', 'unsafe-inline', 'blob:'],
 				'img-src': ['self'],

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -21,6 +21,7 @@ const config = {
 			$components: 'src/lib/components'
 		},
 		csp: {
+			mode: 'hash',
 			directives: {
 				'script-src': ['counterscale.bartveneman.workers.dev', 'self'],
 				'connect-src': ['self', 'counterscale.bartveneman.workers.dev'],

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -22,7 +22,7 @@ const config = {
 		},
 		csp: {
 			directives: {
-				'script-src': ['counterscale.bartveneman.workers.dev', 'self', 'sha256-i711g134ddjh7/AVqzinfA+vmpz5El3oRK6Z+QRNcq4='],
+				'script-src': ['counterscale.bartveneman.workers.dev', 'self'],
 				'connect-src': ['self', 'counterscale.bartveneman.workers.dev'],
 				'style-src': ['self', 'unsafe-inline', 'blob:'],
 				'img-src': ['self'],


### PR DESCRIPTION
## Summary
This PR enables static site generation (prerendering) for the application and refactors the theme system to use client-side detection instead of server-side rendering.

## Key Changes

- **Enable Prerendering**: Added `export const prerender = true` to all public routes and implemented `entries()` functions for dynamic routes to generate static pages at build time
  - Applied to: blog, docs (metrics & recipes), about, CSS code quality, and docs layout pages
  
- **Refactor Theme System**: Moved theme detection from server-side HTML replacement to client-side cookie parsing
  - Changed `data-theme` attribute from dynamic `%sveltekit.theme%` placeholder to static `"system"` default
  - Added inline script in `app.html` that runs before page render to check for theme cookie and apply it immediately
  - Removed `transformPageChunk` logic from `hooks.server.ts` that was replacing the theme placeholder
  
- **Adapter Configuration**: Removed `edge: true` option from the SvelteKit adapter, switching from edge deployment to standard Node.js adapter

## Implementation Details

The theme system now works as follows:
1. Page loads with default `data-theme="system"`
2. Inline script executes immediately to check for `theme` cookie
3. If cookie exists, `data-theme` attribute is updated before page renders
4. This prevents theme flash and works with static prerendering

The prerendering setup uses SvelteKit's `entries()` export to generate all dynamic route variants at build time, enabling full static site generation.

https://claude.ai/code/session_019mWVuALSqjHFjGuVgyY3D4