### PR TITLE
clean up CSP in svelte.config.js

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -30,10 +30,7 @@ const config = {
 				],
 				'connect-src': ['self', 'counterscale.bartveneman.workers.dev'],
 				'style-src': ['self', 'unsafe-inline', 'blob:'],
-				'img-src': ['self'],
-				'frame-src': ['codepen.io'],
 				'worker-src': ['self', 'blob:'],
-				'font-src': ['self', 'https://www.projectwallace.com'],
 				'default-src': ['self']
 			}
 		}


### PR DESCRIPTION
- remove codepen.io frame-src
- default-src is `'self'` so entries with only that can be removed