### PR TITLE
Document why edge deployment is disabled in Netlify adapter config

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -16,6 +16,10 @@ const config = {
 		adapter: adapter({
 			// We don't generate enough traffic to keep edge workers ready, so disable edge to avoid cold-starts
 			// Also cannot run on edge because stylelint requires NodeJS-specific APIs
+			// Side effect: also rules out HTTP 103 Early Hints, since that needs a layer that can send
+			// an informational response before the final one, which Netlify Functions can't do (edge might,
+			// but Netlify has no documented support for it either way, unlike e.g. Cloudflare). SvelteKit
+			// itself has no early-hints API, only an auto Link:rel=preload header on the final response.
 			edge: false,
 			// We split the bundles to not impact other routes with Stylelint's slow start
 			split: true


### PR DESCRIPTION
## Summary
Added clarifying comments to the Netlify adapter configuration explaining the implications of disabling edge deployment, specifically regarding HTTP 103 Early Hints support.

## Key Changes
- Expanded the existing comment about disabling edge deployment to document that this also prevents HTTP 103 Early Hints functionality
- Explained that Early Hints requires an intermediary layer capable of sending informational responses before the final response, which Netlify Functions cannot do
- Noted that while edge workers might theoretically support this, Netlify has no documented support for Early Hints
- Clarified that SvelteKit itself only provides automatic Link:rel=preload headers on the final response, not a dedicated early-hints API

## Implementation Details
The change is purely documentation-focused, adding context to help future maintainers understand the full scope of the `edge: false` configuration decision and its trade-offs.

https://claude.ai/code/session_01NE7tjjv8RUN1wPHYmFmaFf